### PR TITLE
Add include/pharmml/private empty directory to fix generate.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ latex/*
 
 libpharmmlc.so
 include/pharmml/*
+!include/pharmml/private
 !include/pharmml/PharmML_ext.h
 
 *.swp

--- a/include/pharmml/private/.gitignore
+++ b/include/pharmml/private/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Generation expects empty directory but none in repo. Fix with
`.gitignore` in target folder. Enables builds from fresh clone.