### PR TITLE
Windows: update libxml2 + ucrt support

### DIFF
--- a/R/src/Makevars.ucrt
+++ b/R/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/R/src/Makevars.win
+++ b/R/src/Makevars.win
@@ -1,7 +1,7 @@
-LIB_XML ?= ../windows/libxml2-2.9.4
+LIB_XML ?= ../windows/libxml2-2.9.10
 
 LIBSOC_INC_PATH=${LIB_XML}/include/libxml2
-LIBSOC_LIB_PATH=${LIB_XML}/lib/${R_ARCH}
+LIBSOC_LIB_PATH=${LIB_XML}/lib/${R_ARCH}${CRT}
 
 PKG_CFLAGS=-Iinclude -I${LIBSOC_INC_PATH}
 PKG_LIBS=-L${LIBSOC_LIB_PATH} -lxml2 -lz -liconv -llzma -lws2_32

--- a/R/tools/winlibs.R
+++ b/R/tools/winlibs.R
@@ -1,7 +1,7 @@
 # Build against libxml2 from Rtools. This is not be used on CRAN (see Makevars.win)
-if (!file.exists("../windows/libxml2-2.9.4/include/libxml2/libxml/parser.h") && Sys.getenv("LIB_XML") == "") {
+if (!file.exists("../windows/libxml2-2.9.10/include/libxml2/libxml/parser.h") && Sys.getenv("LIB_XML") == "") {
   if(getRversion() < "3.3.0") setInternet2()
-  download.file("https://github.com/rwinlib/libxml2/archive/v2.9.4.zip", "lib.zip", quiet = TRUE)
+  download.file("https://github.com/rwinlib/libxml2/archive/v2.9.10.zip", "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
Hello! I maintain the rwinlib binaries.

I recommend this patch to update libxml2 and support for ucrt toolchains.